### PR TITLE
Add daily appointment reminder notification

### DIFF
--- a/src/renderer/js/app.js
+++ b/src/renderer/js/app.js
@@ -92,7 +92,7 @@ class MedicalClinicPOS {
             appointments.forEach(appointment => {
                 content += `
                     <div class="appointment-item">
-                        <div class="appointment-time">${appointment.time}</div>
+                        <div class="appointment-time">${this.formatTime(appointment.time)}</div>
                         <div class="patient-name">${appointment.patientName}</div>
                         <div class="doctor-name">Dr. ${appointment.doctorName}</div>
                         <div class="text-muted">${appointment.reasonForVisit}</div>
@@ -424,11 +424,16 @@ class MedicalClinicPOS {
 
     formatDate(dateString) {
         const date = new Date(dateString + 'T00:00:00');
-        return date.toLocaleDateString('en-US', { 
-            year: 'numeric', 
-            month: 'short', 
-            day: 'numeric' 
+        return date.toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric'
         });
+    }
+
+    formatTime(timeString) {
+        const date = new Date(`1970-01-01T${timeString}`);
+        return date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
     }
 
     showAlert(message, type) {


### PR DESCRIPTION
## Summary
- Notify receptionists of all same-day appointments via system notification on app startup.
- Display appointment times in reminder modal using 12-hour clock for clarity.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node --check main.js`
- `node --check src/renderer/js/app.js`


------
https://chatgpt.com/codex/tasks/task_e_6891ad53277c832b9e5482c684e59df7