### PR TITLE
feat: add startup appointment reminder

### DIFF
--- a/main.js
+++ b/main.js
@@ -5,6 +5,23 @@ const Database = require('./src/database/database');
 let mainWindow;
 let database;
 
+async function showTodayAppointmentsReminder() {
+  const appointments = await database.getTodayAppointments();
+  if (appointments.length > 0) {
+    const list = appointments
+      .map(a => `${a.patientName} (Dr. ${a.doctorName}) @ ${a.time}`)
+      .join(', ');
+    const message = `Reminder: You have ${appointments.length} appointment${
+      appointments.length > 1 ? 's' : ''
+    } today: ${list}`;
+    dialog.showMessageBox(mainWindow, {
+      type: 'info',
+      title: "Today's Appointments",
+      message
+    });
+  }
+}
+
 function createWindow() {
   mainWindow = new BrowserWindow({
     width: 1200,
@@ -36,6 +53,7 @@ app.whenReady().then(async () => {
   await database.initialize();
 
   createWindow();
+  mainWindow.once('ready-to-show', showTodayAppointmentsReminder);
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {


### PR DESCRIPTION
## Summary
- show a reminder dialog for today's appointments when the app window is ready

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891be5a6324832bae8d297fa7397f31